### PR TITLE
Use iris values for Band/Talk stored when switching to Video

### DIFF
--- a/BRC_Band.ATEMLuaScript
+++ b/BRC_Band.ATEMLuaScript
@@ -9,6 +9,11 @@ if EnviroRead( "BRC_AUTO_ON" ) == "TRUE" then
 end;
 BRCTransition( "auto", true );
 EnviroWrite( "BRC_SCENE_BUTTON", BRC_BUTTON_XK24_BAND );
-BRCCameraIris( BRC_CAMERA_IP_LEFT, 90);
-BRCCameraIris( BRC_CAMERA_IP_CENTER, 90);
-BRCCameraIris( BRC_CAMERA_IP_RIGHT, 90);
+
+VSLog("Left iris is " .. EnviroRead( "BRC_CAMERA_IRIS_LEFT_BAND"));
+VSLog("Center iris is " .. EnviroRead( "BRC_CAMERA_IRIS_CENTER_BAND"));
+VSLog("Right iris is " .. EnviroRead( "BRC_CAMERA_IRIS_RIGHT_BAND"));
+
+BRCCameraIris( BRC_CAMERA_IP_LEFT, EnviroRead( "BRC_CAMERA_IRIS_LEFT_BAND" ) );
+BRCCameraIris( BRC_CAMERA_IP_CENTER, EnviroRead( "BRC_CAMERA_IRIS_CENTER_BAND" ) );
+BRCCameraIris( BRC_CAMERA_IP_RIGHT, EnviroRead( "BRC_CAMERA_IRIS_RIGHT_BAND" ) );

--- a/BRC_Band.ATEMLuaScript
+++ b/BRC_Band.ATEMLuaScript
@@ -10,10 +10,6 @@ end;
 BRCTransition( "auto", true );
 EnviroWrite( "BRC_SCENE_BUTTON", BRC_BUTTON_XK24_BAND );
 
-VSLog("Left iris is " .. EnviroRead( "BRC_CAMERA_IRIS_LEFT_BAND"));
-VSLog("Center iris is " .. EnviroRead( "BRC_CAMERA_IRIS_CENTER_BAND"));
-VSLog("Right iris is " .. EnviroRead( "BRC_CAMERA_IRIS_RIGHT_BAND"));
-
 BRCCameraIris( BRC_CAMERA_IP_LEFT, EnviroRead( "BRC_CAMERA_IRIS_LEFT_BAND" ) );
 BRCCameraIris( BRC_CAMERA_IP_CENTER, EnviroRead( "BRC_CAMERA_IRIS_CENTER_BAND" ) );
 BRCCameraIris( BRC_CAMERA_IP_RIGHT, EnviroRead( "BRC_CAMERA_IRIS_RIGHT_BAND" ) );

--- a/BRC_FadeToBlack.ATEMLuaScript
+++ b/BRC_FadeToBlack.ATEMLuaScript
@@ -5,7 +5,7 @@ BRCFinishActiveTransition();
 
 EnviroWrite( "BRC_SCENE_BUTTON", BRC_BUTTON_XK24_BLACK );
 
-if ATEMMixerCount() > 0 then
+if EnviroRead( "BRC_DEBUG_ATEM" ) ~= "TRUE" and ATEMMixerCount() > 0 then
     if not ATEMMixerMEGetFadedToBlack( 1, 1 ) then
         ATEMMixerMEFadeToBlack( 1, 1 );
     end;

--- a/BRC_TOOLS.ATEMLuaScript
+++ b/BRC_TOOLS.ATEMLuaScript
@@ -144,8 +144,16 @@ function BRCCameraControllerSelectCamera(cameraNumber)
     end;
 end;
 
+function BRCCameraGetIris(cameraIp)
+  local response = HTTPGet( "http://" .. cameraIp .. "/cgi-bin/aw_ptz?cmd=%23GI" .. "&res=1" );
+  VSLog("Iris response for " .. cameraIp .. " is " .. response);
+  local irisValue = string.match(response, 'gi(%x%x%x)');
+  VSLog("Iris value is " .. irisValue);
+  return irisValue;
+end;
+
 function BRCCameraIris(cameraIp, irisValue)
-  HTTPGet( "http://" .. cameraIp .. "/cgi-bin/aw_ptz?cmd=%23I" .. irisValue .. "&res=1" );
+  HTTPGet( "http://" .. cameraIp .. "/cgi-bin/aw_ptz?cmd=%23AXI" .. irisValue .. "&res=1" );
 end;
 
 function BRCCameraPower(power)

--- a/BRC_TOOLS.ATEMLuaScript
+++ b/BRC_TOOLS.ATEMLuaScript
@@ -146,9 +146,7 @@ end;
 
 function BRCCameraGetIris(cameraIp)
   local response = HTTPGet( "http://" .. cameraIp .. "/cgi-bin/aw_ptz?cmd=%23GI" .. "&res=1" );
-  VSLog("Iris response for " .. cameraIp .. " is " .. response);
   local irisValue = string.match(response, 'gi(%x%x%x)');
-  VSLog("Iris value is " .. irisValue);
   return irisValue;
 end;
 

--- a/BRC_TOOLS.ATEMLuaScript
+++ b/BRC_TOOLS.ATEMLuaScript
@@ -177,14 +177,14 @@ function BRCCameraTally()
 end;
 
 function BRCFinishActiveTransition ()
-    if ATEMMixerCount() > 0 and ATEMMixerMEGetTransitionStatusActive( 1, 1 ) then
+    if EnviroRead( "BRC_DEBUG_ATEM" ) ~= "TRUE" and ATEMMixerCount() > 0 and ATEMMixerMEGetTransitionStatusActive( 1, 1 ) then
         ATEMMixerMECut( 1, 1 );
         Sleep( 60 );
     end;
 end;
 
 function BRCPreview(button, xk24Button, input, autoTransition)
-    if ATEMMixerCount() > 0 then
+    if EnviroRead( "BRC_DEBUG_ATEM" ) ~= "TRUE" and ATEMMixerCount() > 0 then
         ATEMMixerMESetPreviewInput( 1, 1, input );
     else
         VSLog("Set preview to input " .. input);
@@ -199,7 +199,7 @@ function BRCPreview(button, xk24Button, input, autoTransition)
 end;
 
 function BRCProject(button, input)
-    if ATEMMixerCount() > 0 then
+    if EnviroRead( "BRC_DEBUG_ATEM" ) ~= "TRUE" and ATEMMixerCount() > 0 then
         ATEMMixerAUXSetInput( 1, 1, input );
     else
         VSLog("Set AUX1 output to input " .. input);
@@ -281,7 +281,7 @@ function BRCTransition (type, wantKey)
 
     BRCCameraTally();
 
-    if atemConnected then
+    if EnviroRead( "BRC_DEBUG_ATEM" ) ~= "TRUE" and atemConnected then
         ATEMMixerMESetNextTransitionLayers( 1, 1, transitionLayers );
 
         if ATEMMixerMEGetFadedToBlack( 1, 1 ) then

--- a/BRC_Talk.ATEMLuaScript
+++ b/BRC_Talk.ATEMLuaScript
@@ -9,6 +9,11 @@ if EnviroRead( "BRC_AUTO_ON" ) == "TRUE" then
 end;
 BRCTransition( "auto", true );
 EnviroWrite( "BRC_SCENE_BUTTON", BRC_BUTTON_XK24_TALK );
-BRCCameraIris( BRC_CAMERA_IP_LEFT, 60);
-BRCCameraIris( BRC_CAMERA_IP_CENTER, 60);
-BRCCameraIris( BRC_CAMERA_IP_RIGHT, 60);
+
+VSLog("Left iris is " .. EnviroRead( "BRC_CAMERA_IRIS_LEFT_TALK"));
+VSLog("Center iris is " .. EnviroRead( "BRC_CAMERA_IRIS_CENTER_TALK"));
+VSLog("Right iris is " .. EnviroRead( "BRC_CAMERA_IRIS_RIGHT_TALK"));
+
+BRCCameraIris( BRC_CAMERA_IP_LEFT, EnviroRead( "BRC_CAMERA_IRIS_LEFT_TALK" ) );
+BRCCameraIris( BRC_CAMERA_IP_CENTER, EnviroRead( "BRC_CAMERA_IRIS_CENTER_TALK" ) );
+BRCCameraIris( BRC_CAMERA_IP_RIGHT, EnviroRead( "BRC_CAMERA_IRIS_RIGHT_TALK" ) );

--- a/BRC_Talk.ATEMLuaScript
+++ b/BRC_Talk.ATEMLuaScript
@@ -10,10 +10,6 @@ end;
 BRCTransition( "auto", true );
 EnviroWrite( "BRC_SCENE_BUTTON", BRC_BUTTON_XK24_TALK );
 
-VSLog("Left iris is " .. EnviroRead( "BRC_CAMERA_IRIS_LEFT_TALK"));
-VSLog("Center iris is " .. EnviroRead( "BRC_CAMERA_IRIS_CENTER_TALK"));
-VSLog("Right iris is " .. EnviroRead( "BRC_CAMERA_IRIS_RIGHT_TALK"));
-
 BRCCameraIris( BRC_CAMERA_IP_LEFT, EnviroRead( "BRC_CAMERA_IRIS_LEFT_TALK" ) );
 BRCCameraIris( BRC_CAMERA_IP_CENTER, EnviroRead( "BRC_CAMERA_IRIS_CENTER_TALK" ) );
 BRCCameraIris( BRC_CAMERA_IP_RIGHT, EnviroRead( "BRC_CAMERA_IRIS_RIGHT_TALK" ) );

--- a/BRC_ToggleKey.ATEMLuaScript
+++ b/BRC_ToggleKey.ATEMLuaScript
@@ -6,7 +6,7 @@ local xk24 = EnviroRead( "BRC_XK24_Index" );
 local brcKeyOn;
 if EnviroRead( "BRC_KEY_ON" ) == "TRUE" then
     brcKeyOn = "FALSE";
-    if ATEMMixerCount() == 0 then
+    if EnviroRead( "BRC_DEBUG_ATEM" ) == "TRUE" or ATEMMixerCount() == 0 then
         VSLog("Transition KEY1 using auto.  Key will be OFF.");
     elseif ATEMMixerMEKeyGetOnAir( 1, 1, 1 ) then
         ATEMMixerMESetNextTransitionLayers( 1, 1, 'KEY1' );
@@ -14,7 +14,7 @@ if EnviroRead( "BRC_KEY_ON" ) == "TRUE" then
     end;
 else
     brcKeyOn = "TRUE";
-    if ATEMMixerCount() == 0 then
+    if EnviroRead( "BRC_DEBUG_ATEM" ) == "TRUE" or ATEMMixerCount() == 0 then
         VSLog("Transition KEY1 using auto.  Key will be ON.");
     elseif not ATEMMixerMEKeyGetOnAir( 1, 1, 1 ) then
         ATEMMixerMESetNextTransitionLayers( 1, 1, 'KEY1' );

--- a/BRC_Video.ATEMLuaScript
+++ b/BRC_Video.ATEMLuaScript
@@ -5,7 +5,23 @@ BRCFinishActiveTransition();
 BRCProject( BRC_BUTTON_PROJECT_COMPUTER, BRC_INPUT_COMPUTER_MASTER );
 BRCPreview( BRC_BUTTON_PREVIEW_COMPUTER, BRC_BUTTON_XK24_PREVIEW_COMPUTER, BRC_INPUT_COMPUTER_MASTER );
 BRCTransition( "auto", false );
+
+local currentScene = tonumber( EnviroRead( "BRC_SCENE_BUTTON" ) );
+if currentScene == BRC_BUTTON_XK24_BAND then
+    VSLog("Saving iris values for BAND");
+    local centeriris = BRCCameraGetIris(BRC_CAMERA_IP_CENTER);
+    VSLog("Center iris is " .. centeriris);
+    EnviroWrite( "BRC_CAMERA_IRIS_LEFT_BAND", BRCCameraGetIris(BRC_CAMERA_IP_LEFT) );
+    EnviroWrite( "BRC_CAMERA_IRIS_CENTER_BAND", BRCCameraGetIris(BRC_CAMERA_IP_CENTER) );
+    EnviroWrite( "BRC_CAMERA_IRIS_RIGHT_BAND", BRCCameraGetIris(BRC_CAMERA_IP_RIGHT) );
+elseif currentScene == BRC_BUTTON_XK24_TALK then
+    VSLog("Saving iris values for TALK");
+    EnviroWrite( "BRC_CAMERA_IRIS_LEFT_TALK", BRCCameraGetIris(BRC_CAMERA_IP_LEFT) );
+    EnviroWrite( "BRC_CAMERA_IRIS_CENTER_TALK", BRCCameraGetIris(BRC_CAMERA_IP_CENTER) );
+    EnviroWrite( "BRC_CAMERA_IRIS_RIGHT_TALK", BRCCameraGetIris(BRC_CAMERA_IP_RIGHT) );
+end;
 EnviroWrite( "BRC_SCENE_BUTTON", BRC_BUTTON_XK24_VIDEO );
+
 if EnviroRead( "BRC_AUTO_ON" ) == "TRUE" then
     Sleep(1000);
     BRCCameraPreset( BRC_CAMERA_IP_CENTER, 6, 8 );

--- a/BRC_Video.ATEMLuaScript
+++ b/BRC_Video.ATEMLuaScript
@@ -8,14 +8,10 @@ BRCTransition( "auto", false );
 
 local currentScene = tonumber( EnviroRead( "BRC_SCENE_BUTTON" ) );
 if currentScene == BRC_BUTTON_XK24_BAND then
-    VSLog("Saving iris values for BAND");
-    local centeriris = BRCCameraGetIris(BRC_CAMERA_IP_CENTER);
-    VSLog("Center iris is " .. centeriris);
     EnviroWrite( "BRC_CAMERA_IRIS_LEFT_BAND", BRCCameraGetIris(BRC_CAMERA_IP_LEFT) );
     EnviroWrite( "BRC_CAMERA_IRIS_CENTER_BAND", BRCCameraGetIris(BRC_CAMERA_IP_CENTER) );
     EnviroWrite( "BRC_CAMERA_IRIS_RIGHT_BAND", BRCCameraGetIris(BRC_CAMERA_IP_RIGHT) );
 elseif currentScene == BRC_BUTTON_XK24_TALK then
-    VSLog("Saving iris values for TALK");
     EnviroWrite( "BRC_CAMERA_IRIS_LEFT_TALK", BRCCameraGetIris(BRC_CAMERA_IP_LEFT) );
     EnviroWrite( "BRC_CAMERA_IRIS_CENTER_TALK", BRCCameraGetIris(BRC_CAMERA_IP_CENTER) );
     EnviroWrite( "BRC_CAMERA_IRIS_RIGHT_TALK", BRCCameraGetIris(BRC_CAMERA_IP_RIGHT) );


### PR DESCRIPTION
When switching to the `Video` scene, each camera iris value will be retrieved and stored into environment variables for the current active scene (`Band` or `Talk`).  When switching to the `Band` or `Talk` scene, the corresponding environment variables will be used to set each camera iris.

Also, support macro debugging when an ATEM switcher is not present or when you do not want to send commands to the connected switcher by setting the `BRC_DEBUG_ATEM` environment variable to `TRUE`.